### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -5200,7 +5200,7 @@ class XChemExplorer(QtGui.QApplication):
 
     def show_data_collection_details(self,state):
         # first remove currently displayed widget
-        if self.data_collection_details_currently_on_display != None:
+        if self.data_collection_details_currently_on_display is not None:
             self.data_collection_details_currently_on_display.hide()
 #            self.data_collection_summarys_vbox_for_details.removeWidget(self.data_collection_details_currently_on_display)
 #            self.data_collection_details_currently_on_display.deleteLater()
@@ -5669,7 +5669,7 @@ class XChemExplorer(QtGui.QApplication):
                 continue        # do not show rows where sampleID is null
             for y,item in enumerate(columns_to_show):
                 cell_text=QtGui.QTableWidgetItem()
-                if row[item]==None:
+                if row[item] is None:
                     cell_text.setText('')
                 else:
                     cell_text.setText(str(row[item]))
@@ -5715,7 +5715,7 @@ class XChemExplorer(QtGui.QApplication):
                             break
             for y,item in enumerate(columns_to_show):
                 cell_text=QtGui.QTableWidgetItem()
-                if row[item]==None:
+                if row[item] is None:
                     cell_text.setText('')
                 else:
                     cell_text.setText(str(row[item]))

--- a/lib/XChemCoot.py
+++ b/lib/XChemCoot.py
@@ -563,7 +563,7 @@ class GUI(object):
 
         self.db_dict_mainTable={}
         self.db_dict_panddaTable={}
-        if str(self.Todo[self.index][0]) != None:
+        if str(self.Todo[self.index][0]) is not None:
             self.compoundID=str(self.Todo[self.index][1])
             self.refinement_folder=str(self.Todo[self.index][4])
             self.refinement_outcome=str(self.Todo[self.index][5])

--- a/lib/XChemCootNew.py
+++ b/lib/XChemCootNew.py
@@ -646,7 +646,7 @@ class GUI(object):
         self.refresh_site_combobox()
         self.db_dict_mainTable={}
         self.db_dict_panddaTable={}
-        if str(self.Todo[self.index][0]) != None:
+        if str(self.Todo[self.index][0]) is not None:
             self.compoundID=str(self.Todo[self.index][1])
             self.refinement_folder=str(self.Todo[self.index][4])
             self.refinement_outcome=str(self.Todo[self.index][5])

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1082,7 +1082,7 @@ class data_source:
         for item in tmp:
             tmpx=[]
             for i in list(item):
-                if i==None:
+                if i is None:
                     tmpx.append('None')
                 else:
                     tmpx.append(i)
@@ -1181,7 +1181,7 @@ class data_source:
         for item in tmp:
             tmpx=[]
             for i in list(item):
-                if i==None:
+                if i is None:
                     tmpx.append('None')
                 else:
                     tmpx.append(i)
@@ -1220,7 +1220,7 @@ class data_source:
         for item in tmp:
             tmpx=[]
             for i in list(item):
-                if i==None:
+                if i is None:
                     tmpx.append('None')
                 else:
                     tmpx.append(i)

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -163,11 +163,11 @@ class update_datasource_from_file_system(QtCore.QThread):
                     db_pandda_dict={}
                     db_pandda_dict['PANDDA_site_index']=entry[1]
                     db_pandda_dict['PANDDApath']=self.panddas_directory
-                    if entry[3] != None:
+                    if entry[3] is not None:
                         event_map=os.path.join(self.initial_model_directory,xtal,entry[3].split('/')[len(entry[3].split('/'))-1])
                         if os.path.isfile(event_map):
                             db_pandda_dict['PANDDA_site_event_map']=event_map
-                    if entry[2] != None:
+                    if entry[2] is not None:
                         spider_plot=os.path.join(self.initial_model_directory,xtal,entry[2].split('/')[len(entry[2].split('/'))-3],entry[2].split('/')[len(entry[2].split('/'))-2],entry[2].split('/')[len(entry[2].split('/'))-1])
                         if os.path.isfile(spider_plot):
                             db_pandda_dict['PANDDA_site_spider_plot']=spider_plot
@@ -885,7 +885,7 @@ class create_png_and_cif_of_compound(QtCore.QThread):
             compoundID=item[1]
             smiles=item[2]
             self.emit(QtCore.SIGNAL('update_status_bar(QString)'), 'creating ACEDRG shell script for '+sampleID)
-            if compoundID=='' or compoundID==None:
+            if compoundID=='' or compoundID is None:
                 compoundID='compound'
 
             if not os.path.isdir(os.path.join(self.initial_model_directory,sampleID)):

--- a/lib/coot_utils_XChem.py
+++ b/lib/coot_utils_XChem.py
@@ -726,7 +726,7 @@ def popen_command(cmd, args, data_list, log_file, screen_flag=False):
             # print "BL DEBUG:: popen command is", cmd_execfile + " " + args_string + " < " + data_list_file + " > " + log_file
             status = os.popen(cmd_execfile + " " + args_string + " < " + data_list_file + " > " + log_file, 'r')
             cmd_finished = status.close()
-            if (cmd_finished != None):
+            if (cmd_finished is not None):
                 print "running command ", cmd, " failed!"
                 return 1
             else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:reskyner:XChemExplorer?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:reskyner:XChemExplorer?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)